### PR TITLE
Accept JS Object in constructor.

### DIFF
--- a/lib/CoolBeans.js
+++ b/lib/CoolBeans.js
@@ -5,7 +5,15 @@ module.exports = function(config){
 	me = this;
 
 	// load the configuration file
-	var json = JSON.parse(fs.readFileSync(config, "utf-8"));
+	var json;
+	switch (typeof config) {
+		case 'object':
+			json = config;
+			break;
+    
+		default:
+			json = JSON.parse(fs.readFileSync(config, "utf-8"));
+	}
 
 	var cache = {};
 


### PR DESCRIPTION
JSON files are cool, but some times there are cases where we prefer to pass the object directly instead of having a json file, or even more we may prefer another format for instance YML and then pass the js object from YML into the constructor as a JS object :)
